### PR TITLE
Template path

### DIFF
--- a/lib/create-library.js
+++ b/lib/create-library.js
@@ -15,6 +15,7 @@ module.exports = async (info) => {
   const {
     manager,
     template,
+    templatePath,
     name
   } = info
 
@@ -26,7 +27,9 @@ module.exports = async (info) => {
   info.dest = dest
   await mkdirp(dest)
 
-  const source = path.join(__dirname, '..', 'template', template)
+  const source = template === 'custom'
+    ? path.join(process.cwd(), templatePath)
+    : path.join(__dirname, '..', 'template', template)
   const files = await globby(source, {
     dot: true
   })

--- a/lib/create-library.test.js
+++ b/lib/create-library.test.js
@@ -52,6 +52,16 @@ const tests = [
     license: 'GPL',
     manager: 'yarn',
     template: 'default'
+  },
+  {
+    name: 'my-custom-template',
+    author: 'nala',
+    description: 'this is a auto-generated test module. please ignore.',
+    repo: 'nala/my-custom-template',
+    license: 'GPL',
+    manager: 'yarn',
+    template: 'custom',
+    templatePath: './template/default'
   }
 ]
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ module.exports = async () => {
     .option('-l, --license <string>', 'package license', defaults.license)
     .option('-r, --repo <string>', 'package repo path')
     .option('-m, --manager <npm|yarn>', 'package manager to use', /^(npm|yarn)$/, defaults.manager)
-    .option('-t, --template <default|typescript>', 'package template to use', /^(default|typescript)$/, defaults.template)
+    .option('-t, --template <default|typescript>', 'package template to use', /^(default|typescript|custom)$/, defaults.template)
+    .option('-p, --template-path <string>', 'custom package template path')
     .option('-s, --skip-prompts', 'skip all prompts (must provide package-name via cli)')
     .parse(process.argv)
 

--- a/lib/prompt-library-params.js
+++ b/lib/prompt-library-params.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const path = require('path')
+const fs = require('fs')
 const inquirer = require('inquirer')
 const validateNpmName = require('validate-npm-package-name')
 
@@ -69,8 +71,23 @@ module.exports = async (opts) => {
         type: 'list',
         name: 'template',
         message: 'Template',
-        choices: [ 'default', 'typescript' ],
+        choices: [ 'default', 'typescript', 'custom' ],
         default: opts.template
+      },
+      {
+        type: 'input',
+        name: 'templatePath',
+        message: 'Template Path',
+        when: ({ template }) => template === 'custom',
+        validate: input => new Promise(resolve => {
+          const fullPath = path.resolve(process.cwd(), input)
+          fs.stat(fullPath, (err, stats) => {
+            if (err) {
+              resolve(`Cannot resolve directory at: ${fullPath}`)
+            }
+            resolve(true)
+          })
+        })
       }
     ])
 

--- a/lib/prompt-library-params.js
+++ b/lib/prompt-library-params.js
@@ -83,7 +83,7 @@ module.exports = async (opts) => {
           const fullPath = path.resolve(process.cwd(), input)
           fs.stat(fullPath, (err, stats) => {
             if (err) {
-              resolve(`Cannot resolve directory at: ${fullPath}`)
+              return resolve(`Cannot resolve directory at: ${fullPath}`)
             }
             resolve(true)
           })

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "inquirer": "^6.0.0",
     "make-dir": "^1.3.0",
     "node-compat-require": "^1.0.5",
-    "ora": "^2.1.0",
+    "ora": "^3.0.0",
     "p-each-series": "^1.0.0",
     "parse-git-config": "^2.0.2",
     "validate-npm-package-name": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,9 +3938,9 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-2.1.0.tgz#6caf2830eb924941861ec53a173799e008b51e5b"
+ora@^3.0.0:
+  version "3.0.0"
+  resolved "https://binrepo.target.com/artifactory/api/npm/npms/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
   dependencies:
     chalk "^2.3.1"
     cli-cursor "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,7 +3940,7 @@ optionator@^0.8.2:
 
 ora@^3.0.0:
   version "3.0.0"
-  resolved "https://binrepo.target.com/artifactory/api/npm/npms/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
   dependencies:
     chalk "^2.3.1"
     cli-cursor "^2.1.0"


### PR DESCRIPTION
This PR is in response to the discussion in #4. 

It adds a prompt option to provide a template path. As far as I can tell, [Inquirer](https://github.com/SBoudrias/Inquirer.js) doesn't have support for a text select or input field. To work around that, I added a "custom" option.

![screen shot 2018-08-13 at 3 06 50 pm](https://user-images.githubusercontent.com/606237/44055306-a2b4b816-9f0a-11e8-879a-2b0c823e09cd.png)

Which provides an interface like so:

![screen shot 2018-08-13 at 3 06 58 pm](https://user-images.githubusercontent.com/606237/44055324-b43ad958-9f0a-11e8-8a76-5721b9c2d754.png)
