### PR TITLE
fixes output typos

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,12 +54,12 @@ module.exports = async () => {
 
   console.log(`
 
-Your module has been created at ${opts.dest}.
+Your module has been created at ${dest}.
 
 To get started, in one tab, run:
 $ cd ${params.shortName} && ${params.manager} start
 
-And in another tab, run the create-react-app devserver:
+And in another tab, run the create-react-app dev server:
 $ cd ${path.join(params.shortName, 'example')} && ${params.manager} start
 `)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,9 +3938,9 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-2.1.0.tgz#6caf2830eb924941861ec53a173799e008b51e5b"
+ora@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
   dependencies:
     chalk "^2.3.1"
     cli-cursor "^2.1.0"


### PR DESCRIPTION
Last one, promise.

I noticed the output seems broken

<img width="455" alt="screen shot 2018-08-13 at 8 42 52 pm" src="https://user-images.githubusercontent.com/606237/44067859-17f8d9cc-9f3d-11e8-9851-ae49b387e916.png">

with changes:

<img width="681" alt="screen shot 2018-08-13 at 9 06 21 pm" src="https://user-images.githubusercontent.com/606237/44067865-1f55b60e-9f3d-11e8-9ef5-e5e19af615cd.png">
