### PR TITLE
Change postcss-modules to postcss

### DIFF
--- a/template/typescript/package.json
+++ b/template/typescript/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
-    "rollup-plugin-postcss-modules": "1.0.8",
+    "rollup-plugin-postcss": "^1.6.2",
     "rollup-plugin-typescript2": "^0.17.0",
     "rollup-plugin-url": "^1.4.0",
     "typescript": "^2.8.3"

--- a/template/typescript/rollup.config.js
+++ b/template/typescript/rollup.config.js
@@ -1,7 +1,8 @@
 import typescript from 'rollup-plugin-typescript2'
 import commonjs from 'rollup-plugin-commonjs'
 import external from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss-modules'
+// import postcss from 'rollup-plugin-postcss-modules'
+import postcss from 'rollup-plugin-postcss'
 import resolve from 'rollup-plugin-node-resolve'
 import url from 'rollup-plugin-url'
 import svgr from '@svgr/rollup'
@@ -27,8 +28,7 @@ export default {
   plugins: [
     external(),
     postcss({
-      modules: true,
-      writeDefinitions: true
+      modules: true
     }),
     url(),
     svgr(),


### PR DESCRIPTION
When creating a new typescript project, I'm currently getting this error with the `rollup-plugin-postcss-modules` package:

![screen shot 2018-10-19 at 9 12 56 am](https://user-images.githubusercontent.com/22530815/47223992-1a944780-d380-11e8-8e3c-c3a131ccc528.png)

I changed `rollup-plugin-postcss-modules` in the typescript template to the `rollup-plugin-postcss` being used in the default template, and that fixed it.