### PR TITLE
fix(templatePath): supply templatePath if specified as default to inquirer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ module.exports = async () => {
     repo: program.repo,
     manager: program.manager,
     template: program.template,
+    templatePath: program.templatePath,
     skipPrompts: program.skipPrompts,
     git: program.git
   }

--- a/lib/prompt-library-params.js
+++ b/lib/prompt-library-params.js
@@ -78,6 +78,7 @@ module.exports = async (opts) => {
         type: 'input',
         name: 'templatePath',
         message: 'Template Path',
+        default: opts.templatePath,
         when: ({ template }) => template === 'custom',
         validate: input => new Promise(resolve => {
           const fullPath = path.resolve(process.cwd(), input)

--- a/lib/prompt-library-params.test.js
+++ b/lib/prompt-library-params.test.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { test } = require('ava')
+
+const promptLibraryParams = require('./prompt-library-params')
+
+const opts = {
+  name: 'my-custom-template',
+  author: 'nala',
+  description: 'this is a auto-generated test module. please ignore.',
+  repo: 'nala/my-custom-template',
+  license: 'GPL',
+  manager: 'yarn',
+  template: 'custom',
+  templatePath: './template/default',
+  git: true
+}
+
+test('passed options are returned when skipPrompts is true', async t => {
+  const result = await promptLibraryParams(Object.assign({}, opts, { skipPrompts: true }))
+  Object.entries(opts).forEach(opt => {
+    // console.log(`comparing passed in option ${opt[0]}:${opt[1]} to returned option ${result[opt[0]]}`)
+    t.is(opt[1], result[opt[0]])
+  })
+})


### PR DESCRIPTION
fixes #93

Adds `templatePath` if set via CLI as an option to inquirer  for the current strategy of confirming default values
