### PR TITLE
Main package.json data reading

### DIFF
--- a/template/default/package.json
+++ b/template/default/package.json
@@ -65,6 +65,7 @@
     "rollup": "^0.64.1",
     "rollup-plugin-babel": "^4.0.1",
     "rollup-plugin-commonjs": "^9.1.3",
+    "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^1.6.2",

--- a/template/default/rollup.config.js
+++ b/template/default/rollup.config.js
@@ -5,6 +5,7 @@ import postcss from 'rollup-plugin-postcss'
 import resolve from 'rollup-plugin-node-resolve'
 import url from 'rollup-plugin-url'
 import svgr from '@svgr/rollup'
+import json from 'rollup-plugin-json'
 
 import pkg from './package.json'
 
@@ -30,10 +31,11 @@ export default {
     url(),
     svgr(),
     babel({
-      exclude: 'node_modules/**',
+      exclude: ['node_modules/**', '*.json'],
       plugins: [ '@babel/external-helpers' ]
     }),
     resolve(),
-    commonjs()
+    commonjs(),
+    json()
   ]
 }


### PR DESCRIPTION
Hi @transitive-bullshit  could you please apply some changes to make possible main package.json data reading from _Example_ application?
I ran into a problem trying to display information about from the main package in the _Example_ application. Unfortunately, the React does not allow to read the information over its scopes without `yarn eject` and modifications...

It looks like so:
**/create-range-gallery/example/src/App.js**
![import rrgv from react](https://user-images.githubusercontent.com/10127643/49366528-9234f080-f6fa-11e8-836a-79a549b53091.PNG)
![react disallowing from scope](https://user-images.githubusercontent.com/10127643/49365843-dfb05e00-f6f8-11e8-933d-76c331a3d71f.PNG)

I have also could't strictley to export data from **/create-range-gallery/src/index.js**
![export package json version](https://user-images.githubusercontent.com/10127643/49366399-526e0900-f6fa-11e8-929b-e1efa9d8616d.PNG)

and then read it from **/create-range-gallery/example/src/App.js**
![import rrgv](https://user-images.githubusercontent.com/10127643/49366588-b5f83680-f6fa-11e8-87c3-340a6c369cba.PNG)
![rollup data reading error](https://user-images.githubusercontent.com/10127643/49367127-366b6700-f6fc-11e8-8bd5-e059e5a17742.PNG)


But after the changes at pull request above I could read main package.json data from the _Example application_ =)
![terminal result](https://user-images.githubusercontent.com/10127643/49366797-52bad400-f6fb-11e8-9f13-edb1da21ba20.PNG)

