### PR TITLE
fixes SVG import

### DIFF
--- a/template/default/rollup.config.js
+++ b/template/default/rollup.config.js
@@ -27,7 +27,7 @@ export default {
     postcss({
       modules: true
     }),
-    url(),
+    url({ exclude: ['**/*.svg'] }),
     svgr(),
     babel({
       exclude: 'node_modules/**',

--- a/template/typescript/rollup.config.js
+++ b/template/typescript/rollup.config.js
@@ -30,7 +30,7 @@ export default {
     postcss({
       modules: true
     }),
-    url(),
+    url({ exclude: ['**/*.svg'] }),
     svgr(),
     resolve(),
     typescript({


### PR DESCRIPTION
url plugin was superseding `svgr` plugin in handling SVGs, so `svgr` was not handling SVGs