### PR TITLE
More commonly used version query

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,7 @@ module.exports = async () => {
 
   program
     .name('create-react-library')
-    .version(version)
+    .version(version, '-v, --version')
     .usage('[options] [package-name]')
     .option('-d, --desc <string>', 'package description')
     .option('-a, --author <string>', 'author\'s github handle', defaults.author)


### PR DESCRIPTION
Thanks for providing such an easy to use tool
 
The Reason:
After some comparisons and references, combined with my own usage habits, `-v` and `--version` are the more common query fields.

PS: I noticed the current situation of the project, I will start to pay attention and keep contributing, so that this project can continue
