### PR TITLE
V2 Add Develop Script

### DIFF
--- a/packages/create-react-library/lib/cli.js
+++ b/packages/create-react-library/lib/cli.js
@@ -60,10 +60,8 @@ module.exports = async () => {
 Your module has been created at ${dest}.
 
 To get started, in one tab, run:
-$ ${chalk.cyan(`cd ${params.shortName} && ${params.manager} start`)}
+$ ${chalk.cyan(`cd ${params.shortName} && ${params.manager} run develop`)}
 
-And in another tab, run the create-react-app dev server:
-$ ${chalk.cyan(`cd ${path.join(params.shortName, 'example')} && ${params.manager} start`)}
 `)
 
   return dest

--- a/packages/create-react-library/template/package.json
+++ b/packages/create-react-library/template/package.json
@@ -20,7 +20,8 @@
     "test": "crl-scripts test",
     "deploy": "crl-scripts deploy",
     "eject": "crl-scripts eject",
-    "prepare": "crl-scripts build"
+    "prepare": "crl-scripts build",
+    "develop": "crl-scripts develop"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/crl-scripts/lib/commands/develop.js
+++ b/packages/crl-scripts/lib/commands/develop.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const concurrently = require('concurrently')
+
+module.exports = (program) => {
+  program
+    .command('develop')
+    .description('Starts the bundler in watch mode for the component and example')
+    .action(async () => {
+      concurrently([
+        'cd example && npm start',
+        'wait-on -d 5000 http://localhost:3000/ && npm start'
+    ], {
+        prefix: 'name',
+        killOthers: ['failure', 'success'],
+        restartTries: 3,
+    })
+    })
+}

--- a/packages/crl-scripts/package.json
+++ b/packages/crl-scripts/package.json
@@ -32,6 +32,7 @@
     "babel-eslint": "^10.0.3",
     "chalk": "^3.0.0",
     "commander": "^4.1.0",
+    "concurrently": "^5.0.2",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-config-standard-react": "^9.2.0",
@@ -57,6 +58,7 @@
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-typescript2": "^0.25.3",
     "rollup-plugin-url": "^3.0.1",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "wait-on": "^4.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > CLI for creating reusable, modern React libraries using Rollup and create-react-app.
 
-[![NPM](https://img.shields.io/npm/v/create-react-library.svg)](https://www.npmjs.com/package/create-react-library) [![Build Status](https://travis-ci.com/transitive-bullshit/create-react-library.svg?branch=master)](https://travis-ci.com/transitive-bullshit/create-react-library) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/create-react-library.svg)](https://www.npmjs.com/package/create-react-library) [![Build Status](https://travis-ci.com/transitive-bullshit/create-react-library.svg?branch=master)](https://travis-ci.com/transitive-bullshit/create-react-library) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 
 
 ## Intro
@@ -72,21 +72,14 @@ At this point, your new module should resemble this screenshot and is all setup 
 
 ## Development
 
-Local development is broken into two parts (ideally using two tabs).
-
-First, run rollup to watch your `src/` module and automatically recompile it into `dist/` whenever you make changes.
-
+Start the development server by running
 ```bash
-npm start # runs rollup with watch flag
+npm run develop
 ```
 
-The second part will be running the `example/` create-react-app that's linked to the local version of your module.
+This will watch your `src/` module and and automatically recompile it into `dist/` whenever you make changes.
 
-```bash
-# (in another tab)
-cd example
-npm start # runs create-react-app dev server
-```
+It will also run the `example/` create-react-app that's linked to the local version of your module.
 
 Now, anytime you make a change to your library in `src/` or to the example app's `example/src`, `create-react-app` will live-reload your local dev server so you can iterate on your component in real-time.
 
@@ -146,8 +139,9 @@ Here are some example libraries that have been bootstrapped with `create-react-l
 - [react-editext](https://github.com/alioguzhan/react-editext) - Editable Text Component.
 - ... and hundreds more!
 
-Want to add yours to the list? Submit an [issue](https://github.com/transitive-bullshit/create-react-library/issues/new).
+Want to see a more complete list? Check out [Made with CRL](https://made-with-crl.netlify.com/)
 
+Want to add yours to the list? Submit an [PR](https://github.com/HurricaneInteractive/made-with-crl#adding-a-library) at the _Made with CRL_ repository.
 
 ## License
 


### PR DESCRIPTION
This change allows the component + example to be ran in development mode by running `npm run develop` instead of running `npm start` and `cd example && npm start` in another terminal

Todo:
* address failing build
* make develop.js switch between `yarn` or `npm` based on user's selection