### PR TITLE
ignores .git folder for template

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,7 +26,10 @@ module.exports = async () => {
     .option('-t, --template <default|typescript>', 'package template to use', /^(default|typescript|custom)$/, defaults.template)
     .option('-p, --template-path <string>', 'custom package template path')
     .option('-s, --skip-prompts', 'skip all prompts (must provide package-name via cli)')
+    .option('-i, --skip-src-template', 'skips handle bars tempalte in src folder (must provide package-name via cli)')
     .parse(process.argv)
+
+
 
   const opts = {
     description: program.desc,
@@ -37,7 +40,8 @@ module.exports = async () => {
     template: program.template,
     templatePath: program.templatePath,
     skipPrompts: program.skipPrompts,
-    git: program.git
+    git: program.git,
+    skipSrcTemplate: program.skipSrcTemplate,
   }
 
   Object.keys(opts).forEach((key) => {
@@ -53,7 +57,7 @@ module.exports = async () => {
     program.help()
     process.exit(1)
   }
-
+  
   const params = await promptLibraryParams(opts)
   const dest = await createLibrary(params)
 

--- a/lib/create-library.js
+++ b/lib/create-library.js
@@ -12,7 +12,7 @@ const pEachSeries = require('p-each-series')
 const pkg = require('../package')
 
 const templateBlacklist = new Set([
-  'example/public/favicon.ico'
+  'example/public/favicon.ico',
 ])
 
 module.exports = async (info) => {
@@ -21,7 +21,8 @@ module.exports = async (info) => {
     template,
     name,
     templatePath,
-    git
+    git,
+    skipSrcTemplate
   } = info
 
   // handle scoped package names
@@ -46,7 +47,8 @@ module.exports = async (info) => {
         file,
         source,
         dest,
-        info
+        info,
+        skipSrcTemplate
       })
     })
     ora.promise(promise, `Copying ${template} template to ${dest}`)
@@ -73,7 +75,8 @@ module.exports.copyTemplateFile = async (opts) => {
     file,
     source,
     dest,
-    info
+    info,
+    skipSrcTemplate
   } = opts
 
   const fileRelativePath = path.relative(source, file)
@@ -82,7 +85,10 @@ module.exports.copyTemplateFile = async (opts) => {
 
   await mkdirp(destFileDir)
 
-  if (templateBlacklist.has(fileRelativePath)) {
+  if (templateBlacklist.has(fileRelativePath) 
+      || (skipSrcTemplate && fileRelativePath.startsWith('src/'))
+      || (skipSrcTemplate && fileRelativePath.startsWith('stories/'))
+      ) {
     const content = fs.readFileSync(file)
     fs.writeFileSync(destFilePath, content)
   } else {

--- a/lib/create-library.js
+++ b/lib/create-library.js
@@ -41,6 +41,7 @@ module.exports = async (info) => {
 
   {
     const promise = pEachSeries(files, async (file) => {
+      if (file.match(/\.git\b/g)) return
       return module.exports.copyTemplateFile({
         file,
         source,

--- a/lib/prompt-library-params.js
+++ b/lib/prompt-library-params.js
@@ -99,7 +99,8 @@ module.exports = async (opts) => {
 
     return {
       ...info,
-      git: opts.git
+      git: opts.git,
+      skipSrcTemplate: opts.skipSrcTemplate,
     }
   }
 }


### PR DESCRIPTION
fixes #203 

This actually makes templates usable. Otherwise the code try to run handlebars on top of .git files. The original intent of custom template is for users to use their own folders and it would make sense to allow them to maintain their own template using git