### PR TITLE
chore: update deprecated rollup dev dependencies

### DIFF
--- a/template/default/package.json
+++ b/template/default/package.json
@@ -47,6 +47,8 @@
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "@svgr/rollup": "^2.4.1",
     "babel-eslint": "^10.0.1",
     "cross-env": "^5.1.4",
@@ -64,8 +66,6 @@
     "react-scripts": "^1.1.4",
     "rollup": "^0.64.1",
     "rollup-plugin-babel": "^4.0.1",
-    "rollup-plugin-commonjs": "^9.1.3",
-    "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^1.6.2",
     "rollup-plugin-url": "^1.4.0"

--- a/template/default/rollup.config.js
+++ b/template/default/rollup.config.js
@@ -1,24 +1,24 @@
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
-import external from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss'
-import resolve from 'rollup-plugin-node-resolve'
-import url from 'rollup-plugin-url'
-import svgr from '@svgr/rollup'
+import babel from "rollup-plugin-babel";
+import commonjs from "@rollup/plugin-commonjs";
+import external from "rollup-plugin-peer-deps-external";
+import postcss from "rollup-plugin-postcss";
+import resolve from "@rollup/plugin-node-resolve";
+import url from "rollup-plugin-url";
+import svgr from "@svgr/rollup";
 
-import pkg from './package.json'
+import pkg from "./package.json";
 
 export default {
-  input: 'src/index.js',
+  input: "src/index.js",
   output: [
     {
       file: pkg.main,
-      format: 'cjs',
+      format: "cjs",
       sourcemap: true
     },
     {
       file: pkg.module,
-      format: 'es',
+      format: "es",
       sourcemap: true
     }
   ],
@@ -27,13 +27,13 @@ export default {
     postcss({
       modules: true
     }),
-    url({ exclude: ['**/*.svg'] }),
+    url({ exclude: ["**/*.svg"] }),
     svgr(),
     babel({
-      exclude: 'node_modules/**',
-      plugins: [ '@babel/external-helpers' ]
+      exclude: "node_modules/**",
+      plugins: ["@babel/external-helpers"]
     }),
     resolve(),
     commonjs()
   ]
-}
+};

--- a/template/typescript/package.json
+++ b/template/typescript/package.json
@@ -29,6 +29,8 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime": "^7.0.0",
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "@svgr/rollup": "^2.4.1",
     "@types/jest": "^23.1.5",
     "@types/react": "^16.8.0",
@@ -40,8 +42,6 @@
     "react-scripts": "^2.1.0",
     "rollup": "^0.62.0",
     "rollup-plugin-babel": "^4.0.1",
-    "rollup-plugin-commonjs": "^9.1.3",
-    "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^1.6.2",
     "rollup-plugin-typescript2": "^0.17.0",

--- a/template/typescript/rollup.config.js
+++ b/template/typescript/rollup.config.js
@@ -1,27 +1,27 @@
-import typescript from 'rollup-plugin-typescript2'
-import commonjs from 'rollup-plugin-commonjs'
-import external from 'rollup-plugin-peer-deps-external'
+import typescript from "rollup-plugin-typescript2";
+import commonjs from "@rollup/plugin-commonjs";
+import external from "rollup-plugin-peer-deps-external";
 // import postcss from 'rollup-plugin-postcss-modules'
-import postcss from 'rollup-plugin-postcss'
-import resolve from 'rollup-plugin-node-resolve'
-import url from 'rollup-plugin-url'
-import svgr from '@svgr/rollup'
+import postcss from "rollup-plugin-postcss";
+import resolve from "@rollup/plugin-node-resolve";
+import url from "rollup-plugin-url";
+import svgr from "@svgr/rollup";
 
-import pkg from './package.json'
+import pkg from "./package.json";
 
 export default {
-  input: 'src/index.tsx',
+  input: "src/index.tsx",
   output: [
     {
       file: pkg.main,
-      format: 'cjs',
-      exports: 'named',
+      format: "cjs",
+      exports: "named",
       sourcemap: true
     },
     {
       file: pkg.module,
-      format: 'es',
-      exports: 'named',
+      format: "es",
+      exports: "named",
       sourcemap: true
     }
   ],
@@ -30,7 +30,7 @@ export default {
     postcss({
       modules: true
     }),
-    url({ exclude: ['**/*.svg'] }),
+    url({ exclude: ["**/*.svg"] }),
     svgr(),
     resolve(),
     typescript({
@@ -39,4 +39,4 @@ export default {
     }),
     commonjs()
   ]
-}
+};


### PR DESCRIPTION
there are 2 plugins that were deprecated, warning show that