### PR TITLE
chore(css module): add LESS SCSS definition for typescript (css module)

### DIFF
--- a/template/typescript/src/typings.d.ts
+++ b/template/typescript/src/typings.d.ts
@@ -1,8 +1,16 @@
 /**
- * Default CSS definition for typescript,
+ * Default CSS LESS SCSS definition for typescript,
  * will be overridden with file-specific definitions by rollup
  */
 declare module '*.css' {
+  const content: { [className: string]: string };
+  export default content;
+}
+declare module '*.scss' {
+  const content: { [className: string]: string };
+  export default content;
+}
+declare module '*.less' {
   const content: { [className: string]: string };
   export default content;
 }


### PR DESCRIPTION
TS definition warning when i use "./styles.module.less" in css modules 
`import styles from './styles.module.less'` 

So I add these definition to solve this . 