### PR TITLE
Update deprecated type

### DIFF
--- a/template/typescript/src/typings.d.ts
+++ b/template/typescript/src/typings.d.ts
@@ -15,7 +15,7 @@ declare module '*.less' {
   export default content;
 }
 
-interface SvgrComponent extends React.StatelessComponent<React.SVGAttributes<SVGElement>> {}
+interface SvgrComponent extends React.FunctionComponent<React.SVGAttributes<SVGElement>> {}
 
 declare module '*.svg' {
   const svgUrl: string;


### PR DESCRIPTION
@deprecated
as of recent React versions, function components can no longer be considered 'stateless'. Please use FunctionComponent instead.